### PR TITLE
Fix audit log

### DIFF
--- a/src/main/java/it/pagopa/pn/apikey/manager/controller/ApiKeysController.java
+++ b/src/main/java/it/pagopa/pn/apikey/manager/controller/ApiKeysController.java
@@ -62,10 +62,7 @@ public class ApiKeysController implements ApiKeysApi {
         PnAuditLogBuilder logEventBuilder = buildAuditLogForChangeStatus(requestApiKeyStatusDto.getStatus(),
                 xPagopaPnCxId, xPagopaPnCxGroups,xPagopaPnCxType,xPagopaPnUid);
 
-        PnAuditLogEvent logEvent = logEventBuilder.cxId(xPagopaPnCxId)
-                .cxType(xPagopaPnCxType.getValue())
-                .uid(xPagopaPnUid)
-                .build();
+        PnAuditLogEvent logEvent = logEventBuilder.build();
 
         logEvent.log();
 
@@ -105,9 +102,6 @@ public class ApiKeysController implements ApiKeysApi {
 
         PnAuditLogEvent logEvent = auditLogBuilder
                 .before(PnAuditLogEventType.AUD_AK_DELETE, logMessage)
-                .cxId(xPagopaPnCxId)
-                .cxType(xPagopaPnCxType.getValue())
-                .uid(xPagopaPnUid)
                 .build();
 
         logEvent.log();
@@ -147,9 +141,6 @@ public class ApiKeysController implements ApiKeysApi {
 
         PnAuditLogEvent logEvent = auditLogBuilder
                 .before(PnAuditLogEventType.AUD_AK_VIEW, logMessage)
-                .cxId(xPagopaPnCxId)
-                .cxType(xPagopaPnCxType.getValue())
-                .uid(xPagopaPnUid)
                 .build();
 
         logEvent.log();
@@ -187,9 +178,6 @@ public class ApiKeysController implements ApiKeysApi {
 
         PnAuditLogEvent logEvent = auditLogBuilder
                 .before(PnAuditLogEventType.AUD_AK_CREATE, logMessage)
-                .cxId(xPagopaPnCxId)
-                .cxType(xPagopaPnCxType.getValue())
-                .uid(xPagopaPnUid)
                 .build();
 
         logEvent.log();

--- a/src/test/java/it/pagopa/pn/apikey/manager/controller/ApiKeysControllerTest.java
+++ b/src/test/java/it/pagopa/pn/apikey/manager/controller/ApiKeysControllerTest.java
@@ -90,9 +90,6 @@ class ApiKeysControllerTest {
         RequestApiKeyStatusDto requestApiKeyStatusDto = new RequestApiKeyStatusDto();
         requestApiKeyStatusDto.setStatus(status);
         when(auditLogBuilder.before(any(),any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.uid(any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.cxId(any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.cxType(any())).thenReturn(auditLogBuilder);
         when(auditLogBuilder.build()).thenReturn(pnAuditLogEvent);
         StepVerifier.create(apiKeysController.changeStatusApiKey("foo", CxTypeAuthFleetDto.PA, "foo", "foo", requestApiKeyStatusDto, xPagopaPnCxGroups,
                         new DefaultServerWebExchange(serverHttpRequestDecorator, response, webSessionManager, codecConfigurer,
@@ -119,9 +116,6 @@ class ApiKeysControllerTest {
         MockServerHttpResponse response = new MockServerHttpResponse();
         DefaultServerCodecConfigurer codecConfigurer = new DefaultServerCodecConfigurer();
         when(auditLogBuilder.before(any(),any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.uid(any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.cxId(any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.cxType(any())).thenReturn(auditLogBuilder);
         when(auditLogBuilder.build()).thenReturn(pnAuditLogEvent);
         StepVerifier.create(apiKeysController.deleteApiKeys("foo", CxTypeAuthFleetDto.PA, "foo", "foo", xPagopaPnCxGroups,
                         new DefaultServerWebExchange(serverHttpRequestDecorator, response, webSessionManager, codecConfigurer,
@@ -159,9 +153,6 @@ class ApiKeysControllerTest {
 
         ResponseEntity<ResponseNewApiKeyDto> responseEntity = ResponseEntity.ok().body(apiKeyModel);
         when(auditLogBuilder.before(any(),any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.uid(any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.cxId(any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.cxType(any())).thenReturn(auditLogBuilder);
         when(auditLogBuilder.build()).thenReturn(pnAuditLogEvent);
         StepVerifier.create(apiKeysController.newApiKey("uid", CxTypeAuthFleetDto.PA, "cxId", requestNewApiKeyDto, xPagopaPnCxGroups,
                         new DefaultServerWebExchange(serverHttpRequestDecorator, response, webSessionManager, codecConfigurer,
@@ -188,9 +179,6 @@ class ApiKeysControllerTest {
         when(manageApiKeyService.getApiKeyList(anyString(), any(), any(), any(), any(), anyBoolean(), eq(xPagopaPnCxType)))
                 .thenReturn(Mono.just(apiKeysResponseDto));
         when(auditLogBuilder.before(any(),any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.uid(any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.cxId(any())).thenReturn(auditLogBuilder);
-        when(auditLogBuilder.cxType(any())).thenReturn(auditLogBuilder);
         when(auditLogBuilder.build()).thenReturn(pnAuditLogEvent);
         StepVerifier.create(apiKeysController.getApiKeys(xPagopaPnUid, xPagopaPnCxType, xPagopaPnCxId, xPagopaPnCxGroups, 10, lastKey, lastUpdate, showVirtualKey, serverWebExchange))
                 .expectNext(ResponseEntity.ok().body(apiKeysResponseDto));


### PR DESCRIPTION
Rimosse le invocazioni ai metodi cxId() uid() e cxType() in seguito alla rimozione degli stessi metodi da PnAuditLogBuilder